### PR TITLE
Remove Attribute error

### DIFF
--- a/feedservice/parse/text.py
+++ b/feedservice/parse/text.py
@@ -49,11 +49,10 @@ class ConvertMarkdown(object):
 
     def process(self, html_str):
         import html2text
-        import html.parser
 
         try:
             text = html2text.html2text(html_str)
             return text.strip()
 
-        except (TypeError, html.parser.HTMLParseError):
+        except Exception:
             return ''


### PR DESCRIPTION
html.parser.HTMLParseError has been deprecated since python 3.5. I
removed it as a choice.

Fixes #438